### PR TITLE
add basic ABI/bindgen support for resources

### DIFF
--- a/crates/wit-parser/src/sizealign.rs
+++ b/crates/wit-parser/src/sizealign.rs
@@ -36,7 +36,9 @@ impl SizeAlign {
             TypeDefKind::Future(_) => (4, 4),
             // A stream is represented as an index.
             TypeDefKind::Stream(_) => (4, 4),
-            TypeDefKind::Resource => unreachable!(),
+            // This shouldn't be used for anything since raw resources aren't part of the ABI -- just handles to
+            // them.
+            TypeDefKind::Resource => (usize::MAX, usize::MAX),
             TypeDefKind::Unknown => unreachable!(),
         }
     }


### PR DESCRIPTION
These additions are needed for `wit-bindgen` guest binding generation.